### PR TITLE
Add a POC compartmentalization library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Libraries
+*.lib
+*.a
+
+# Shared objects
+*.so
+*.so.*
+
+# Executables
+*.out
+
+# astyle
+*.orig

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,19 @@
+Except as otherwise noted (below and/or in individual files), this project is
+licensed under the Apache License, Version 2.0 <LICENSE-APACHE>
+<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT>
+<http://opensource.org/licenses/MIT>, at your option.
+
+Copyright is retained by contributors and/or the organisations they
+represent(ed) -- this project does not require copyright assignment. Please see
+version control history for a full list of contributors. Note that some files
+may include explicit copyright and/or licensing notices.
+
+The following contributors wish to explicitly make it known that the copyright
+of their contributions is retained by an organisation:
+
+    Aleks Bonin <mrabonin@gmail.com> <aleks@bonin.tech>:
+      copyright retained by King's College London
+    Jacob Bramley <jacob.bramley@arm.com>:
+      copyright retained by Arm Limited
+    Laurence Tratt <laurie@tratt.net>:
+      copyright retained by King's College London

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+CHERIBASE   ?= $(HOME)/cheri
+SDKBASE     ?= $(CHERIBASE)/output/morello-sdk
+CFLAGS      := --config cheribsd-morello-hybrid.cfg
+PLATFORM    := morello-hybrid
+CC          := $(SDKBASE)/bin/clang
+CFORMAT     := $(SDKBASE)/bin/clang-format
+BINDIR      := bin/$(PLATFORM)
+
+RUNUSER     ?= root
+RUNHOST     ?= localhost
+RUNDIR      ?=
+
+ifdef RUNDIR
+RUNDIR      := $(RUNDIR)/cheri-comp
+else
+RUNDIR      := cheri-comp
+endif
+
+LIBNAME     := libcomp.so
+SRC         := $(wildcard src/*.S) $(wildcard src/*.s) $(wildcard src/*.c)
+EXAMPLE_SRC := $(wildcard example/*.S) $(wildcard example/*.s) $(wildcard example/*.c)
+CFLAGS      += -Wall -Wextra -Werror -pedantic --std=c17 -fPIC -lelf -g
+
+.PRECIOUS: $(BINDIR)/%
+
+.PHONY: run fmt
+
+run: $(BINDIR)/example $(BINDIR)/$(LIBNAME)
+ifdef SSHPORT
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) 'mkdir -p $(RUNDIR)'
+	scp $(SCP_OPTIONS) -P $(SSHPORT) $^ $(RUNUSER)@$(RUNHOST):$(RUNDIR)
+	scp $(SCP_OPTIONS) -P $(SSHPORT) -r $$(pwd) $(RUNUSER)@$(RUNHOST):$(RUNDIR)
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) -t 'cd $(RUNDIR) && LD_LIBRARY_PATH=. ./$(<F)'
+else
+	@echo "'$@' requires SSHPORT to be defined."
+	@false
+endif
+
+$(BINDIR)/example: $(EXAMPLE_SRC) $(BINDIR)/$(LIBNAME)
+	@mkdir -p $(BINDIR)
+	$(CC) $(CFLAGS) -I./src/ -lcomp -L $(BINDIR) $(EXAMPLE_SRC) -o $@
+
+$(BINDIR)/$(LIBNAME): $(SRC)
+	@mkdir -p $(BINDIR)
+	$(CC) $(CFLAGS) -Wl,-Bsymbolic,-shared -L $(BINDIR) $+ -o $@
+
+fmt:
+	astyle \
+		--break-return-type \
+		--align-pointer=name \
+		--style=attach \
+		--indent-switches \
+		--max-code-length=100 \
+		--recursive './*.c,*.h' \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
 # cheri-compartments-playground
+
+## Aim
+
+This repo contains a proof-of-concept hybrid compartmentalization library for CheriBSD (for the
+`morello-hybrid` target).
+
+The aim of the library is to provide tooling for compartmentalizing existing C programs with respect
+to code and data.
+
+The library aims to support:
+* execution compartmentalization: the PCC of each compartment is restricted according to the bounds
+  established (statically) using the `__comp(COMP_NAME)` macro
+* data compartmentalization: compartments have separate and non-overlapping data regions (TODO: this
+  restriction will need to be relaxed to support data sharing between compartments)
+
+The implementation is heavily inspired by [`inter_comp_call` hybrid compartmentalization examples]
+from the CapableVMs [cheri-examples] repository.
+
+## Usage
+
+Entering and switching compartments can be achieved using:
+* `comp_enter(dst_fn)`, which switches from "normal" execution to compartmentalized execution,
+  jumping to the specified function
+* `comp_call(src, dst_fn)`, a macro that initiates a switch from the `src` compartment to the
+  `dst_fn` function (which is executed in a separate compartment). Note: the fact that `src` must be
+  specified by the `comp_call` caller is a limitation of the current implementation (in an ideal
+  world, they would only need to specify the target function)
+
+Note: The `__comp(COMP_NAME)` macro is meant to be used as a function attribute and is necessary for
+execution compartmentalization. Each function must be associated with a compartment (identified by
+`<COMP_NAME>`), and each compartment can comprise multiple functions (thus, compartments can have
+multiple entry points). Under the hood, the macro places the annotated function in a
+`.cheri_comp_<COMP_NAME>` section.
+
+## Known limitations
+
+* all the limitations of the the [`inter_comp_call` hybrid compartmentalization examples] from the
+  CapableVMs [cheri-examples] repository (since this is heavily inspired by it)
+* the "glue" code required for compartment switching/entering is not auto-generated (the user of the
+  library has to make sure it is present)
+* the existing code is very fragile: it expects the compartment trampolines to precede the
+  compartment code (however, nothing actually enforces this ordering). A potential solution would be
+  to use a linker script to make sure the trampolines stay put
+* lack of automated tests
+* the managing compartment doesn't implement any sort of memory management (the memory region
+  designated as the compartment data area is used as a stack)
+* the library heavily relies on global variables
+* `dladdr` and `dl_iterate_phdr` are non-standard (although in practice, I think they're both
+  implemented on all the platforms we target)
+
+[`inter_comp_call` hybrid compartmentalization examples]: https://github.com/capablevms/cheri-examples/blob/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0/hybrid/compartment_examples/inter_comp_call/malicious_compartments/shared/switch_compartment.S
+[cheri-examples]: https://github.com/capablevms/cheri-examples/tree/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0
+
+## Build instructions
+
+### Prerequisites
+
+Build and run CheriBSD for the `morello-hybrid` target using [`cheribuild`].
+
+### Running the example
+
+To build and run the example:
+
+```
+SSHPORT=<your QEMU ssh port> make  run
+```
+
+The resulting `example` and `libcomp.so` binaries are generated in
+`bin/morello-hybrid/`.
+
+[`cheribuild`]: https://github.com/CTSRD-CHERI/cheribuild

--- a/example/glue.s
+++ b/example/glue.s
@@ -1,0 +1,55 @@
+// TODO these should be auto-generated/copied into every compartment
+.macro trampoline
+    str       clr, [sp, #-16]!
+    blr       c0
+    ldr       clr, [sp], #16
+    ret       clr
+.endm
+
+.macro switch_glue
+    str       clr, [sp, #-16]!
+    mrs       c9, ddc
+    // *DDC contains the address of the sealed switcher capability
+    ldr       c9, [x9]
+    mrs       c1, ddc
+    mov       x2, sp
+    // C9 contains the address of the sealed switcher capability
+    ldpblr    c29, [c9]
+    // Restore the clr
+    ldr       clr, [sp], #16
+    ret
+.endm
+
+// TODO make sure the trampolines stay at the beginning of the section
+.section .cheri_comp_foo
+
+// void __foo_trampoline(void *__capability target_addr);
+.globl __foo_trampoline
+__foo_trampoline:
+    trampoline
+
+.globl __foo_switch_glue
+__foo_switch_glue:
+    switch_glue
+
+.section .cheri_comp_bar
+
+// void __bar_trampoline(void *__capability target_addr);
+.globl __bar_trampoline
+__bar_trampoline:
+    trampoline
+
+.globl __bar_switch_glue
+__bar_switch_glue:
+    switch_glue
+
+.section .cheri_comp_baz
+
+// void __baz_trampoline(void *__capability target_addr);
+.globl __baz_trampoline
+__baz_trampoline:
+    trampoline
+
+.globl __baz_switch_glue
+__baz_switch_glue:
+    switch_glue

--- a/example/main.c
+++ b/example/main.c
@@ -1,0 +1,59 @@
+#include "comp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * Compartment baz
+ */
+__comp("baz") void
+baz(void) {
+    // todo: do something
+}
+
+/*
+ * Compartment bar
+ */
+__comp("bar") void
+bar(void) {
+    comp_call(bar, baz);
+}
+
+__comp("bar") void
+qux(void) {
+    // todo: do something
+}
+
+/*
+ * Compartment foo
+ */
+__comp("foo") void
+foo(void) {
+    // Compartment bar can be entered via any of its functions
+    comp_call(foo, bar);
+    comp_call(foo, qux);
+}
+
+__comp("foo") void
+comp_main(void) {
+    foo();
+}
+
+int
+main(int argc __attribute__((unused)), char **argv) {
+    if (comp_init(argv[0])) {
+        perror("failed to initialize compartmentalization lib");
+
+        return EXIT_FAILURE;
+    }
+
+    // NOTE: `comp_main` is not the only entry point of the foo compartment. We
+    // could've just as well entered the compartment through `foo`.
+    if (comp_enter(comp_main)) {
+        perror("failed to enter compartment");
+
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/comp.c
+++ b/src/comp.c
@@ -1,0 +1,249 @@
+// Inspired by the [hybrid compartmentalization examples] from the CapableVMs
+// [cheri-examples] repository.
+//
+// [hybrid compartmentalization examples]: https://github.com/capablevms/cheri-examples/blob/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0/hybrid/compartment_examples/inter_comp_call/malicious_compartments/shared/switch_compartment.S
+// [cheri-examples]: https://github.com/capablevms/cheri-examples/tree/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0
+
+#include "comp.h"
+
+#include <elf.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <link.h>
+#include <dlfcn.h>
+#include <assert.h>
+
+#include <cheriintrin.h>
+
+#define __comp_mgr_data __attribute__((section(".data.cheri_comp_manager")))
+#define __comp_mgr_code __attribute__((section(".cheri_comp_manager")))
+#define MAX_SHNUM 256
+
+extern void __comp_mgr_code enter_compartment(void *sp, void *__capability comp_pcc,
+        void *__capability comp_ddc, void *__capability comp_entry);
+
+extern void __comp_mgr_code __comp_mgr_code_start(void);
+
+extern size_t __comp_mgr_code next_comp_id(void);
+extern void __comp_mgr_data_start(void);
+
+// A handle to the currently executing binary.
+static __comp_mgr_data FILE *ELF = NULL;
+// The ELF header of the binary.
+static __comp_mgr_data Elf64_Ehdr ELF_HDR = {0};
+// The cached seciton headers.
+static __comp_mgr_data Elf64_Shdr SHDRS[MAX_SHNUM] = {0};
+// The manager DDC and PCC.
+static __comp_mgr_data void *__capability DDC_PCC[2];
+// The sealed manager DDC and PCC.
+static __comp_mgr_data void *__capability SWITCHER_CAPS = NULL;
+// The manager PCC.
+static __comp_mgr_data void *__capability MGR_PCC = NULL;
+// The manager DDC.
+static __comp_mgr_data void *__capability MGR_DDC = NULL;
+
+// Compartment data area.
+// NOTE: This is currently only used for the compartment stack.
+static
+__attribute__((aligned(16))) char COMP_DATA[COMP_TOTAL_DATA_SIZE] = {0};
+
+// The address of `COMP_DATA`.
+//
+// This address must be stored within the boundaries of the compartment manager
+// data section during initialization, before restricting the DDC (this is
+// necessary because the address of `COMP_DATA` is loaded from a literal pool
+// located outside the managing compartment boundary).
+//
+// TODO: come up with a more readable workaround.
+static __comp_mgr_data void *__capability COMP_DATA_ADDR = NULL;
+
+static inline  __comp_mgr_code void
+seal_cap(void *__capability cap) {
+    __asm__("seal %w0, %w0, lpb" : "+r"(cap) :);
+}
+
+// Parse the section headers of the specified binary.
+static __comp_mgr_code int
+init_elf_info(char *bin_path) {
+    if ((ELF = fopen(bin_path, "r")) == NULL) {
+        perror("failed to open file");
+        return EXIT_FAILURE;
+    }
+
+    if (fread(&ELF_HDR, sizeof(ELF_HDR), 1, ELF) != 1) {
+        perror("failed to read ELF header");
+        return EXIT_FAILURE;
+    }
+
+    if (ELF_HDR.e_shnum > MAX_SHNUM) {
+        return EXIT_FAILURE;
+    }
+
+    for (size_t i = 0; i < ELF_HDR.e_shnum; ++i) {
+        if (fseek(ELF, ELF_HDR.e_shoff + i * sizeof(Elf64_Shdr), SEEK_SET)) {
+            return EXIT_FAILURE;
+        }
+
+        if (fread(&SHDRS[i], sizeof(Elf64_Shdr), 1, ELF) != 1) {
+            return EXIT_FAILURE;
+        }
+    }
+
+    return EXIT_SUCCESS;
+}
+
+// Find the section `fn_addr` is located in.
+//
+// The section bounds are used to restrict the PCC of the compartment.
+static __comp_mgr_code void
+find_section(void *fn_addr, Elf64_Addr *sh_addr, Elf64_Xword *sh_size) {
+    uintptr_t addr = (uintptr_t)fn_addr;
+
+    for (size_t i = 0; i < ELF_HDR.e_shnum; ++i) {
+        uintptr_t section_start = SHDRS[i].sh_addr;
+        uintptr_t section_end = SHDRS[i].sh_addr + SHDRS[i].sh_size;
+
+        if (addr >= section_start && addr < section_end) {
+            *sh_addr = SHDRS[i].sh_addr;
+            *sh_size = SHDRS[i].sh_size;
+
+            return;
+        }
+    }
+}
+
+static void *__capability
+make_comp_ddc(size_t comp_id) {
+    // `COMP_DATA_ADDR` is statically allocated region logically divided into
+    // `COMP_DDC_SIZE` chunks (each chunk represents the data region of a
+    // compartment).
+    void *__capability ddc = COMP_DATA_ADDR;
+    size_t comp_offset = comp_id * COMP_DDC_SIZE;
+    uintptr_t ddc_addr = (uintptr_t)((char *)cheri_address_get(ddc) + comp_offset);
+
+    ddc = cheri_address_set(ddc, ddc_addr);
+    ddc = cheri_bounds_set(ddc, COMP_DDC_SIZE);
+
+    return ddc;
+}
+
+static __comp_mgr_code int
+make_comp_caps(void *__capability *pcc, void *__capability *ddc, void (*fn_addr)()) {
+    // Create compartment info
+    Elf64_Addr sh_addr = 0;
+    Elf64_Xword sh_size = 0;
+
+    find_section((void *)fn_addr, &sh_addr, &sh_size);
+
+    if (!sh_size) {
+        return EXIT_FAILURE;
+    }
+
+    // Note: it's not possible to directly derive a valid capability from
+    // sh_addr and sh_size (it has to be derived from fn_addr)
+    *pcc = (void *__capability)fn_addr;
+    *pcc = cheri_address_set(*pcc, sh_addr);
+    *pcc = cheri_bounds_set(*pcc, sh_size);
+
+    // TODO: dynamically allocate the compartment data area.
+    *ddc = make_comp_ddc(next_comp_id());
+
+    return EXIT_SUCCESS;
+}
+
+static __comp_mgr_code int
+find_mgr_ddc(struct dl_phdr_info *info, size_t size __attribute__((unused)), void *data __attribute__((unused))) {
+    for (int i = 0; i < info->dlpi_phnum; ++i) {
+        uintptr_t addr  = info->dlpi_addr + info->dlpi_phdr[i].p_vaddr;
+
+        if ((uintptr_t)&__comp_mgr_data_start >= addr
+                && (uintptr_t)&__comp_mgr_data_start < addr + info-> dlpi_phdr[i].p_memsz) {
+            MGR_DDC = cheri_address_set(MGR_DDC, addr);
+            // TODO: are the bounds correct?
+            MGR_DDC = cheri_bounds_set(MGR_DDC, info->dlpi_phdr[i].p_memsz);
+        }
+
+        if (MGR_DDC) {
+            // This tells dl_iterate_phdr to stop iterating.
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+// Initialize and restrict the DDC and PCC
+static __comp_mgr_code int
+find_comp_mgr_bounds() {
+    MGR_PCC = (void *__capability)__comp_mgr_code_start;
+    // TODO: restrict the PCC of the managing compartment?
+
+    Dl_info dl_info;
+
+    // Find out where we are loaded
+    if (!dladdr((void *)&__comp_mgr_data_start, &dl_info)) {
+        return EXIT_FAILURE;
+    }
+
+    MGR_DDC = (void *__capability)dl_info.dli_fbase;
+
+    // Figure out the bounds of the segment we're in
+    dl_iterate_phdr(find_mgr_ddc, NULL);
+
+    if (MGR_PCC == NULL || MGR_DDC == NULL) {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+__comp_mgr_code int
+comp_init(char *bin_path) {
+    // Initialize `SHDRS` with the the section headers of the currently
+    // executing binary. These are needed by `make_comp_caps` to determine the
+    // PCC bounds when entering a compartment via `comp_enter` or `comp_call`.
+    if (init_elf_info(bin_path)) {
+        perror("failed to read ELF");
+        return EXIT_FAILURE;
+    }
+
+    // Prepare the compartment manager (by initializing `MGR_DDC` and `MGR_PCC`).
+    if (find_comp_mgr_bounds()) {
+        return EXIT_FAILURE;
+    }
+
+    // To understand why this is needed, see the comment above `COMP_DATA_ADDR`.
+    COMP_DATA_ADDR = &COMP_DATA;
+    DDC_PCC[0] = MGR_DDC;
+    DDC_PCC[1] = MGR_PCC;
+
+    SWITCHER_CAPS = (void *__capability)DDC_PCC;
+
+    seal_cap(SWITCHER_CAPS);
+
+    return EXIT_SUCCESS;
+}
+
+__comp_mgr_code int
+comp_enter(void (*comp_entry_fn)()) {
+    void *__capability comp_pcc = NULL;
+    void *__capability comp_ddc = NULL;
+
+    // Set up the PCC and DDC for the compartment we're about to enter.
+    if (make_comp_caps(&comp_pcc, &comp_ddc, comp_entry_fn)) {
+        return EXIT_FAILURE;
+    }
+
+    void *comp_stack_top = (void *)((char *)__builtin_cheri_address_get(comp_ddc)  + COMP_STACK_OFFSET);
+
+    // Copy the manager caps into each compartment (to enable compartment switching).
+    void *__capability *comp_ddc_addr = (void *__capability *)__builtin_cheri_address_get(comp_ddc);
+    *comp_ddc_addr = SWITCHER_CAPS;
+
+    enter_compartment(comp_stack_top, comp_pcc, comp_ddc, (void *__capability)comp_entry_fn);
+
+    // TODO free or reuse compartment resources
+    return EXIT_SUCCESS;
+}

--- a/src/comp.h
+++ b/src/comp.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// The maximum supported number of compartments
+#define COMP_MAX_COMP_COUNT        4
+// The size of the compartment data area
+#define COMP_DDC_SIZE              4096
+// The total size of the area allocated for compartment data
+#define COMP_TOTAL_DATA_SIZE       (COMP_MAX_COMP_COUNT * COMP_DDC_SIZE)
+// The offset of the compartment stack in the data area
+#define COMP_STACK_OFFSET          3072
+// The maximum size allowed for any given compartment switch stack frame.
+// NOTE: in practice, nothing prevents the managing compartment from creating
+// frames that exceed the maxium frame size (however, doing so would corrupt the
+// other active frames on the call stack).
+#define COMP_MGR_FRAME_SIZE        4096
+#define COMP_MGR_TOTAL_STACK_SIZE  (COMP_MAX_COMP_COUNT * COMP_MGR_FRAME_SIZE)
+
+#ifndef __ASSEMBLY__
+
+// Initiate a compartment switch from `SRC_COMP` to `TARGET_FN` (in another compartment).
+#define comp_call(SRC_COMP, TARGET_FN)               \
+    __asm__("adr x0, " #TARGET_FN "\n\t"             \
+            "str clr, [sp, #-16]!\n\t"               \
+            "bl __" #SRC_COMP "_switch_glue\n\t"     \
+            "ldr clr, [sp], #16\n\t");
+
+#define __comp(COMP_NAME) __attribute__((section(".cheri_comp_" COMP_NAME)))
+
+// Initialize the library.
+int comp_init(char *bin_path);
+
+// Create a compartment with the specified entry point and jump to it.
+int comp_enter(void (*comp_entry)());
+
+#endif

--- a/src/switch.S
+++ b/src/switch.S
@@ -1,0 +1,202 @@
+// Inspired by https://github.com/capablevms/cheri-examples/blob/master/hybrid/compartment_examples/inter_comp_call/malicious_compartments/shared/switch_compartment.S
+
+#define __ASSEMBLY__
+
+#include "comp.h"
+
+.section ".data.cheri_comp_manager"
+
+.globl __comp_mgr_data_start
+.hidden __comp_mgr_data_start
+__comp_mgr_data_start:
+
+.align 16
+// An area reserved for the stack of the compartment manager (used for
+// executing compartment swicthes).
+COMP_MGR_STACK_BOTTOM:
+    .fill COMP_MGR_TOTAL_STACK_SIZE - 16, 1, 0
+COMP_MGR_STACK_TOP:
+    .fill 16, 1, 0
+
+COMP_CALL_ID:
+    .long 0
+
+// TODO: make sure `comp_switch` stays at the beginning of the .cheri_comp_manager
+// section!!!
+//
+// It is essential that `comp_switch` stays at the beginning of the
+// section because the compartment manager PCC is initialized to
+// `__comp_mgr_code_start` whenver a compartment switch is initiated.
+.section ".cheri_comp_manager", "ax", @progbits
+
+// Read the value of COMP_CALL_ID into the specified register.
+.macro comp_id to
+    adr       \to, COMP_CALL_ID
+    ldr       \to, [\to]
+.endm
+
+// Create a new manager stack frame for exectuing a compartment switch.
+//
+// This logically divides [COMP_MGR_STACK_BOTTOM, COMP_MGR_STACK_TOP] into
+// frames (one frame for each compartment switch initiated using `comp_call`):
+//
+//                                                       _________________________
+//  COMP_MGR_STACK_BOTTOM ----------------------------> |                         |
+//                                                      |    comp_call frame 1    |
+//                                                      |_________________________|
+//  COMP_MGR_STACK_BOTTOM + COMP_MGR_FRAME_SIZE ------> |                         |
+//                                                      |    comp_call frame 2    |
+//                                                      |_________________________|
+//                                                      |                         |
+//                                                                ...
+//                                                      |_________________________|
+//                                                      |                         |
+//                                                      |    comp_call frame N    |
+//  COMP_MGR_STACK_TOP -------------------------------> |_________________________|
+//
+// This macro returns the top of the newly allocated frame in the specified
+// register (`\to`).
+.macro make_frame to
+    // Read the value of `COMP_CALL_ID` into X9
+    comp_id    x9
+    // Load the manager stack
+    adr        \to, COMP_MGR_STACK_BOTTOM
+    // Use X9 to index through
+    mov        x10, COMP_MGR_FRAME_SIZE
+    mul        x9, x9, x10
+    add        \to, \to, x9
+.endm
+
+.globl __comp_mgr_code_start
+.hidden __comp_mgr_code_start
+__comp_mgr_code_start:
+
+// Switch to another compartment.
+//
+// Arguments:
+//   C0  - target function (which might be in a different compartment)
+//   C1  - source DDC
+//   X2  - source SP
+//   C29 - manager DDC
+comp_switch:
+    // The target DDC is stored in C29 (by a ldpblr instruction from the
+    // compartment glue).
+    msr        ddc, c29
+
+    // Allocate a new stack frame.
+    //
+    // After allocating the new frame, the SP is updated accordingly (i.e. it is
+    // initialized to the highest address of the frame):
+    //                        ...
+    //             |_________________________| <--- low
+    //             |                         |
+    //             |    comp_call frame M    |
+    //  SP ------> |_________________________| <---- high
+    make_frame x6
+    mov        sp, x6
+
+    // Store the source DDC and the old SP
+    stp        c1, clr, [sp, #-48]!
+    str        x2, [sp, #32]
+
+    // Stack layout at this point:
+    //
+    //     `stack + size` -> ________________________
+    //            sp + 40 -> [  <alignment pad>  ]   ^
+    //            sp + 32 -> [ old SP            ]   |
+    //            sp + 24 -> [ old CLR (hi64)    ]   |
+    //            sp + 16 -> [ old CLR (lo64)    ]   | DDC bounds
+    //            sp +  8 -> [ old DDC (high 64) ]   |
+    //            sp +  0 -> [ old DDC (low 64)  ]   |
+    //                                 :             :
+    //            `stack` -> ________________________v
+
+    // Enter the target compartment
+    bl         comp_enter
+    // Restore the source DDC and the SP
+    ldp        c1, clr, [sp], #32
+    ldr        x2, [sp], #16
+    msr        ddc, c1
+    mov        sp, x2
+    ret        clr
+
+// Increment the compartment count and return its previous value.
+//
+// NOTE: this equivalent to `return COMP_CALL_ID++;`.
+//
+// `COMP_CALL_ID` is used to index through `COMP_DATA_ADDR` and
+// `COMP_MGR_STACK_BOTTOM`. A better solution would be to dynamically allocate
+// (mmap) compartment data regions/compartment manager stack frames.
+//
+// XXX: This is never decremented, so bad things happen if more than
+// `COMP_MAX_COMP_COUNT` calls are executed.
+.globl next_comp_id
+.hidden next_comp_id
+next_comp_id:
+   adr         x9, COMP_CALL_ID
+   ldr         x0, [x9]
+   add         x10, x0, 1
+   str         x10, [x9]
+   ret
+
+// Enter the specified compartment
+//
+// Arguments:
+//   C0 - the SP of the compartment
+//   C1 - the PCC of the compartment
+//   C2 - the DDC of the compartment
+//   C3 - the address to jump to within the compartment
+.globl enter_compartment
+.hidden enter_compartment
+enter_compartment:
+    cvtp       clr, lr
+    // Save the old DDC
+    mrs        c9, DDC
+    // Save the old SP
+    mov        x10, sp
+    // Install the new SP
+    mov        sp, x0
+    // Store the old CFP, CLR on the new stack
+    stp        cfp, clr, [sp, #-64]!
+    // Save the old DDC (C9) on the new stack
+    str        c9, [sp, #32]
+    // Save the old SP (X10) on the new stack
+    str        x10, [sp, #48]
+
+    // Stack layout at this point:
+    //
+    //     `stack + size` -> ________________________
+    //            sp + 54 -> [  <alignment pad>  ]   ^
+    //            sp + 48 -> [      old SP       ]   |
+    //            sp + 40 -> [ old DDC (high 64) ]   |
+    //            sp + 32 -> [ old DDC (low 64)  ]   |
+    //            sp + 24 -> [ old CLR (hi64)    ]   |
+    //            sp + 16 -> [ old CLR (lo64)    ]   | DDC bounds
+    //            sp +  8 -> [ old CFP (high 64) ]   |
+    //            sp +  0 -> [ old CFP (low 64)  ]   |
+    //                                 :             :
+    //            `stack` -> ________________________v
+
+    // Install compartment DDC
+    msr        DDC, c2
+    // C3 contains the address to jump to
+    mov        c0, c3
+    // Jump into the compartment.
+    //
+    // NOTE: This instruction jumps to the address specified in the PCC, which
+    // is not necessarily the appropriate place to enter the compartment. For
+    // this reason, the code of every compartment is preceded by a trampoline,
+    // which jumps to the desired entry point (specified in C0).
+    blr        c1
+
+    // Restore CFP CLR
+    ldp        cfp, clr, [sp]
+    // Restore DDC, stack
+    ldr        c9, [sp, #32]
+    ldr        x10, [sp, #48]
+    msr        DDC, c9
+    mov        sp, x10
+    ret
+
+// Dump the literal pool within the compartment boundary
+.ltorg


### PR DESCRIPTION
This adds a proof-of-concept hybrid compartmentalization library for CheriBSD (for the `morello-hybrid` target).

The aim of the library is to provide tooling for compartmentalizing existing C programs with respect to code and data.

The library aims to support:
* execution compartmentalization: the PCC of each compartment is restricted according to the bounds established (statically) using the `__comp(COMP_NAME)` macro
* data compartmentalization: compartments have separate and non-overlapping data regions (TODO: this restriction will need to be relaxed to support data sharing between compartments)

See README.md for more details.