### PR TITLE
Add a proof-of-concept compartmentalization library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Libraries
+*.lib
+*.a
+
+# Shared objects
+*.so
+*.so.*
+
+# Executables
+*.out
+bin/*
+
+# astyle
+*.orig

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,19 @@
+Except as otherwise noted (below and/or in individual files), this project is
+licensed under the Apache License, Version 2.0 <LICENSE-APACHE>
+<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT>
+<http://opensource.org/licenses/MIT>, at your option.
+
+Copyright is retained by contributors and/or the organisations they
+represent(ed) -- this project does not require copyright assignment. Please see
+version control history for a full list of contributors. Note that some files
+may include explicit copyright and/or licensing notices.
+
+The following contributors wish to explicitly make it known that the copyright
+of their contributions is retained by an organisation:
+
+    Aleks Bonin <mrabonin@gmail.com> <aleks@bonin.tech>:
+      copyright retained by King's College London
+    Jacob Bramley <jacob.bramley@arm.com>:
+      copyright retained by Arm Limited
+    Laurence Tratt <laurie@tratt.net>:
+      copyright retained by King's College London

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+CHERIBASE        ?= $(HOME)/cheri
+SDKBASE          ?= $(CHERIBASE)/output/morello-sdk
+CFLAGS           := --config cheribsd-morello-hybrid.cfg
+CC               := $(SDKBASE)/bin/clang
+BINDIR           := bin
+
+RUNUSER          ?= root
+RUNHOST          ?= localhost
+RUNDIR           ?= /root
+
+LIBNAME          := libcomp.so
+CFILES           := $(wildcard src/*.c)
+HFILES           := $(wildcard src/*.h)
+SRC              := $(wildcard src/*.S src/*.s) $(CFILES)
+TEST_DIR         := tests
+TESTS            := $(notdir $(wildcard $(TEST_DIR)/*))
+TEST_TARGETS     := $(foreach test, $(TESTS), $(BINDIR)/tests/$(test))
+TEST_RUN_TARGETS := $(foreach test, $(TESTS), run-$(test))
+
+CFLAGS           += -Wall -Wextra -Werror -pedantic --std=c17 -fPIC -lelf -g
+
+.PHONY: fmt test $(TEST_RUN_TARGETS)
+
+run-%: $(BINDIR)/tests/% $(BINDIR)/$(LIBNAME)
+ifdef SSHPORT
+	scp $(SCP_OPTIONS) -P $(SSHPORT) -r $$(pwd) $(RUNUSER)@$(RUNHOST):$(RUNDIR)
+	ssh $(SSH_OPTIONS) -p $(SSHPORT) $(RUNUSER)@$(RUNHOST) -t 'cd $(RUNDIR)/cheri-comp && LD_LIBRARY_PATH=./bin/ ./bin/tests/$(<F)'
+else
+	@echo "'$@' requires SSHPORT to be defined."
+	@false
+endif
+
+test: $(TEST_TARGETS)
+	scp $(SCP_OPTIONS) -P $(SSHPORT) -r $$(pwd) $(RUNUSER)@$(RUNHOST):$(RUNDIR)
+	SSH_OPTIONS=$(SSH_OPTIONS) RUNUSER=$(RUNUSER) RUNHOST=$(RUNHOST) RUNDIR=$(RUNDIR) SSHPORT=$(SSHPORT) ./test.bats
+
+# clang-format refuses to format the code properly (it won't respect the
+# `AlwaysBreakAfterReturnType: AllDefinitions` setting)
+fmt:
+	astyle \
+		--break-return-type \
+		--align-pointer=name \
+		--style=attach \
+		--indent-switches \
+		--max-code-length=100 \
+		--recursive './*.c,*.h' \
+
+$(BINDIR)/$(LIBNAME): $(SRC)
+	@mkdir -p $(BINDIR)
+	$(CC) $(CFLAGS) -Wl,-Bsymbolic,-shared -L $(BINDIR) $+ -o $@
+
+.SECONDEXPANSION:
+$(BINDIR)/tests/%: $$(wildcard $(TEST_DIR)/%/glue.S) $$(wildcard $(TEST_DIR)/%/*.c) $(BINDIR)/$(LIBNAME)
+	@mkdir -p $(BINDIR)/tests
+	$(CC) $(CFLAGS) -I./src/ -lcomp -L $(BINDIR) $+ -o $@

--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
 # cheri-compartments-playground
+
+## Aim
+
+This repo contains a proof-of-concept hybrid compartmentalization library for CheriBSD (for the
+`morello-hybrid` target).
+
+This library provides tooling for compartmentalizing existing C programs. It aims to support:
+* execution compartmentalization: the PCC of each compartment is restricted according to the bounds
+  established (statically) using the `__comp(COMP_NAME)` macro
+* data compartmentalization: compartments have separate and non-overlapping data regions (TODO: this
+  restriction will need to be relaxed to support data sharing between compartments)
+
+The implementation is heavily inspired by [`inter_comp_call` hybrid compartmentalization examples]
+from the CapableVMs [cheri-examples] repository. It doesn't add anything new other than the use of
+sections to delineate compartment boundaries (for execution compartmentalization), and support for
+compartments with multiple entry points.
+
+## Usage
+
+Entering and switching compartments can be achieved using:
+* `comp_enter(dst_fn)`, which switches from "normal" (unrestricted) execution to compartmentalized
+  (restricted) execution, jumping to the specified function
+* `comp_call(src, dst_fn)`, a macro that initiates a switch from compartment `src` to the
+  `dst_fn` function (which is executed in a separate compartment). `comp_call` transfers control to
+  `comp_switch` (in the managing compartment), which creates a new compartment for `dst_fn` to
+  execute in and jumps to the newly created compartment. Note: the fact that `src` must be specified
+  by the `comp_call` caller is a limitation of the current implementation (in an ideal world, they
+  would only need to specify the target function).
+
+Note: The `__comp(COMP_NAME)` macro is meant to be used as a function attribute and is necessary for
+execution compartmentalization. Each function must be associated with a compartment (identified by
+`<COMP_NAME>`), and each compartment can comprise multiple functions (thus, compartments can have
+multiple entry points). Under the hood, the macro places the annotated function in a
+`.cheri_comp_<COMP_NAME>` section.
+
+## Known limitations
+
+* all the limitations of the the [`inter_comp_call` hybrid compartmentalization examples] from the
+  CapableVMs [cheri-examples] repository (since this is heavily inspired by it)
+* `comp_init` requires the caller to supply the name of the executable
+* `comp_call` requires the caller to supply the name of the calling compartment (`src`)
+* the glue code required for compartment switching/entering is not auto-generated (the user of the
+  library has to make sure it is present)
+* the existing code is very fragile: it expects the compartment trampolines to precede the
+  compartment code (however, nothing actually enforces this ordering). A potential solution would be
+  to use a linker script to make sure the trampolines code stays put
+* the managing compartment doesn't implement any sort of memory management (the memory region
+  designated as the compartment data area is used as a stack). In other words, compartmentalized
+  programs can only use the stack (i.e. they cannot access global variables, the heap, or anything
+  else outside the bounds of the memory area allocated by the compartment manager). As a
+  consequence, compartmentalized programs can't call many of the functions from the standard
+  library (as they depend on state located outside the compartment bounds)
+
+## Build instructions
+
+### Prerequisites
+
+Build and run CheriBSD for the `morello-hybrid` target using [`cheribuild`].
+
+### Running the tests
+
+The tests can be found in [`test.bats`](./test.bats). You can run them using:
+
+```
+SSHPORT=<your QEMU ssh port> make test
+```
+
+If you want to build and run a specific test program, use one of the `run-<test name>` targets:
+```
+SSHPORT=<your QEMU ssh port> make run-<test name>
+```
+
+where `<test name>` is the name one of the subdirectories of `tests`.
+
+The resulting binaries are generated in `bin/`:
+
+```
+bin
+├── libcomp.so
+└── tests
+    ├── nested-comp-switch
+    ├── out-of-bounds-call
+    └── simple-comp-switch
+```
+
+[`inter_comp_call` hybrid compartmentalization examples]: https://github.com/capablevms/cheri-examples/blob/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0/hybrid/compartment_examples/inter_comp_call/malicious_compartments/shared/switch_compartment.S
+[cheri-examples]: https://github.com/capablevms/cheri-examples/tree/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0
+[`cheribuild`]: https://github.com/CTSRD-CHERI/cheribuild

--- a/src/asmacros.h
+++ b/src/asmacros.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// TODO these should be auto-generated/copied into every compartment
+#define SWITCH_GLUE                                                    \
+    str       clr, [sp, #-16]!                                        ;\
+    mrs       c9, ddc                                                 ;\
+    /* *DDC contains the address of the sealed switcher capability */ ;\
+    ldr       c9, [x9]                                                ;\
+    mrs       c1, ddc                                                 ;\
+    mov       x2, sp                                                  ;\
+    /* C9 contains the address of the sealed switcher capability */   ;\
+    ldpblr    c29, [c9]                                               ;\
+    /* Restore the clr */                                             ;\
+    ldr       clr, [sp], #16                                          ;\
+    ret
+
+#define TRAMPOLINE                                                     \
+    str       clr, [sp, #-16]!                                        ;\
+    blr       x0                                                      ;\
+    ldr       clr, [sp], #16                                          ;\
+    ret       clr

--- a/src/comp.c
+++ b/src/comp.c
@@ -1,0 +1,181 @@
+// Inspired by the [hybrid compartmentalization examples] from the CapableVMs
+// [cheri-examples] repository.
+//
+// [hybrid compartmentalization examples]: https://github.com/capablevms/cheri-examples/blob/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0/hybrid/compartment_examples/inter_comp_call/malicious_compartments/shared/switch_compartment.S
+// [cheri-examples]: https://github.com/capablevms/cheri-examples/tree/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0
+
+#include "comp.h"
+
+#include <assert.h>
+#include <elf.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <cheriintrin.h>
+
+// The size of the compartment data area
+#define COMP_DDC_SIZE              4096
+// The offset of the compartment stack in the data area
+#define COMP_STACK_OFFSET          3072
+#define MAX_SHNUM                  256
+
+extern void enter_compartment(void *sp, void *__capability comp_pcc,
+                              void *__capability comp_ddc, void (*comp_entry_fn)());
+
+extern void comp_switch(void);
+
+// A handle to the currently executing binary.
+static FILE *ELF = NULL;
+// The ELF header of the binary.
+static Elf64_Ehdr ELF_HDR = {0};
+// The cached seciton headers.
+static Elf64_Shdr SHDRS[MAX_SHNUM] = {0};
+// The sealed manager DDC and PCC.
+static void *__capability SWITCHER_CAPS = NULL;
+
+static inline  void
+seal_cap(void *__capability cap) {
+    __asm__("seal %w0, %w0, lpb" : "+r"(cap) :);
+}
+
+static inline void *__capability
+read_ddc() {
+    void *__capability ddc = NULL;
+    __asm__("mrs %w0, DDC\n\t" : [ddc] "=C"(ddc) ::);
+    return ddc;
+}
+
+void *
+make_manager_stack(void) {
+    return calloc(COMP_MGR_STACK_SIZE, 1);
+}
+
+// Parse the section headers of the specified binary.
+static int
+init_elf_info(char *bin_path) {
+    if ((ELF = fopen(bin_path, "r")) == NULL) {
+        perror("failed to open file");
+        return EXIT_FAILURE;
+    }
+
+    if (fread(&ELF_HDR, sizeof(ELF_HDR), 1, ELF) != 1) {
+        perror("failed to read ELF header");
+        return EXIT_FAILURE;
+    }
+
+    if (ELF_HDR.e_shnum > MAX_SHNUM) {
+        return EXIT_FAILURE;
+    }
+
+    if (fseek(ELF, ELF_HDR.e_shoff, SEEK_SET)) {
+        return EXIT_FAILURE;
+    }
+
+    for (size_t i = 0; i < ELF_HDR.e_shnum; ++i) {
+        if (fread(&SHDRS[i], sizeof(Elf64_Shdr), 1, ELF) != 1) {
+            return EXIT_FAILURE;
+        }
+    }
+
+    return EXIT_SUCCESS;
+}
+
+// Find the section `fn_addr` is located in.
+//
+// The section bounds are used to restrict the PCC of the compartment.
+static void
+find_section(void *fn_addr, Elf64_Addr *sh_addr, Elf64_Xword *sh_size) {
+    uintptr_t addr = (uintptr_t)fn_addr;
+
+    for (size_t i = 0; i < ELF_HDR.e_shnum; ++i) {
+        uintptr_t section_start = SHDRS[i].sh_addr;
+        uintptr_t section_end = SHDRS[i].sh_addr + SHDRS[i].sh_size;
+
+        if (addr >= section_start && addr < section_end) {
+            *sh_addr = SHDRS[i].sh_addr;
+            *sh_size = SHDRS[i].sh_size;
+
+            return;
+        }
+    }
+}
+
+static void *__capability
+make_comp_ddc() {
+    void *__capability ddc = (void *__capability)calloc(COMP_DDC_SIZE, 1);
+    ddc = cheri_bounds_set(ddc, COMP_DDC_SIZE);
+
+    return ddc;
+}
+
+static int
+make_comp_caps(void *__capability *pcc, void *__capability *ddc, void (*fn_addr)()) {
+    // Create compartment info
+    Elf64_Addr sh_addr = 0;
+    Elf64_Xword sh_size = 0;
+
+    find_section((void *)fn_addr, &sh_addr, &sh_size);
+
+    if (!sh_size) {
+        return EXIT_FAILURE;
+    }
+
+    // Note: it's not possible to directly derive a valid capability from
+    // sh_addr and sh_size (it has to be derived from fn_addr)
+    *pcc = (void *__capability)fn_addr;
+    *pcc = cheri_address_set(*pcc, sh_addr);
+    *pcc = cheri_bounds_set(*pcc, sh_size);
+    *ddc = make_comp_ddc();
+
+    return EXIT_SUCCESS;
+}
+
+int
+comp_init(char *bin_path) {
+    // TODO: figure out the path of the executable using something like
+    // /proc/self/exe (without requiring the caller to provide it)
+
+    // Initialize `SHDRS` with the the section headers of the currently
+    // executing binary. These are needed by `make_comp_caps` to determine the
+    // PCC bounds when entering a compartment via `comp_enter` or `comp_call`.
+    if (init_elf_info(bin_path)) {
+        perror("failed to read ELF");
+        return EXIT_FAILURE;
+    }
+
+    void *__capability *ddc_pcc = malloc(2 * sizeof(void *__capability));
+    ddc_pcc[0] = read_ddc();
+    ddc_pcc[1] = (void *__capability)comp_switch;
+    // The compartment manager capabilities, which need to be copied into every compartment (they
+    // are needed for compartment switching).
+    SWITCHER_CAPS = (void *__capability)ddc_pcc;
+    seal_cap(SWITCHER_CAPS);
+
+    return EXIT_SUCCESS;
+}
+
+int
+comp_enter(void (*comp_entry_fn)()) {
+    void *__capability comp_pcc = NULL;
+    void *__capability comp_ddc = NULL;
+
+    // Set up the PCC and DDC for the compartment we're about to enter.
+    if (make_comp_caps(&comp_pcc, &comp_ddc, comp_entry_fn)) {
+        return EXIT_FAILURE;
+    }
+
+    void *comp_stack_top = (void *)((char *)__builtin_cheri_address_get(comp_ddc)  + COMP_STACK_OFFSET);
+
+    // Copy the compartment manager capabilities into each compartment (to enable compartment
+    // switching).
+    void *__capability *comp_ddc_addr = (void *__capability *)__builtin_cheri_address_get(comp_ddc);
+    *comp_ddc_addr = SWITCHER_CAPS;
+
+    enter_compartment(comp_stack_top, comp_pcc, comp_ddc, comp_entry_fn);
+
+    // TODO free or reuse compartment resources
+    return EXIT_SUCCESS;
+}

--- a/src/comp.h
+++ b/src/comp.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// The size of the manager stack (which needs to be manually set up whenever a
+// compartment switch is initiated).
+#define COMP_MGR_STACK_SIZE        4096
+
+#ifndef _ASM
+
+// Initiate a compartment switch from `SRC_COMP` to `TARGET_FN` (in another compartment).
+#define comp_call(SRC_COMP, TARGET_FN)               \
+    __asm__("adr x0, " #TARGET_FN "\n\t"             \
+            "str clr, [sp, #-16]!\n\t"               \
+            "bl __" #SRC_COMP "_switch_glue\n\t"     \
+            "ldr clr, [sp], #16\n\t");
+
+#define __comp(COMP_NAME) __attribute__((section(".cheri_comp_" COMP_NAME)))
+
+/**
+ * Initialize the library.
+ */
+int comp_init(char *bin_path);
+
+/**
+ * Create a compartment for the specified entry point function and jump to it.
+ */
+int comp_enter(void (*comp_entry)());
+
+#endif

--- a/src/switch.S
+++ b/src/switch.S
@@ -1,0 +1,161 @@
+// Inspired by https://github.com/capablevms/cheri-examples/blob/master/hybrid/compartment_examples/inter_comp_call/malicious_compartments/shared/switch_compartment.S
+
+#define _ASM
+
+#include "comp.h"
+
+#define COMP_MGR_TMP_STACK_SIZE 1024
+
+.data
+.align 16
+// An area which serves as provisional stack for the compartment manager.
+//
+// When a compartment switch is initiated, the stack of the caller is replaced
+// with the provisional stack. Once the provisional stack is installed, we call
+// `make_manager_stack` to allocate the "real" stack of the manager.
+COMP_MGR_TMP_STACK:
+    .fill COMP_MGR_TMP_STACK_SIZE - 16, 1, 0
+COMP_MGR_TMP_STACK_TOP:
+    .fill 16, 1, 0
+
+.text
+
+.macro save_regs
+    stp	c0, c1, [sp, #-32]!
+    stp	c2, c3, [sp, #-32]!
+    stp	c4, c5, [sp, #-32]!
+    stp	c6, c7, [sp, #-32]!
+    stp	c8, c9, [sp, #-32]!
+    stp	c10, c11, [sp, #-32]!
+    stp	c12, c13, [sp, #-32]!
+    stp	c14, c15, [sp, #-32]!
+    stp	c16, c17, [sp, #-32]!
+    stp	c29, c30, [sp, #-32]!
+.endm
+
+.macro load_regs
+    ldp	c29, c30, [sp], #32
+    ldp	c16, c17, [sp], #32
+    ldp	c14, c15, [sp], #32
+    ldp	c12, c13, [sp], #32
+    ldp	c10, c11, [sp], #32
+    ldp	c8, c9, [sp], #32
+    ldp	c6, c7, [sp], #32
+    ldp	c4, c5, [sp], #32
+    ldp	c2, c3, [sp], #32
+    ldp	c0, c1, [sp], #32
+.endm
+
+// Switch to another compartment.
+//
+// `comp_switch` is reached by calling `comp_call` from a compartment (which
+// executes an `ldpblr` instruction to branch to this code)
+//
+// Arguments:
+//   X0  - target function (which might be in a different compartment)
+//   C1  - source DDC
+//   X2  - source SP
+//   C29 - manager DDC
+.globl comp_switch
+.hidden comp_switch
+comp_switch:
+    // The target DDC is stored in C29 (by a ldpblr instruction from the
+    // compartment glue).
+    msr        ddc, c29
+    // Install a temporary stack to call `make_manager_stack` (which creates the
+    // stack frame for the compartment switch).
+    adr        x9, COMP_MGR_TMP_STACK_TOP
+    mov        x10, sp
+    mov        sp, x9
+    // Save the caller-saved registers (which could be clobbered by `make_manager_stack`)
+    save_regs
+    bl         make_manager_stack
+    mov        x19, x0
+    // Restore the caller-saved registers
+    load_regs
+    // Use the stack returned by `make_manager_stack`
+    mov        sp, x19
+
+    // Store the source DDC and the old SP
+    stp        c1, clr, [sp, #-48]!
+    str        x10, [sp, #32]
+
+    // Stack layout at this point:
+    //
+    //     `stack + size` -> ________________________
+    //            sp + 40 -> [  <alignment pad>  ]   ^
+    //            sp + 32 -> [ old SP            ]   |
+    //            sp + 24 -> [ old CLR (hi64)    ]   |
+    //            sp + 16 -> [ old CLR (lo64)    ]   | DDC bounds
+    //            sp +  8 -> [ old DDC (high 64) ]   |
+    //            sp +  0 -> [ old DDC (low 64)  ]   |
+    //                                 :             :
+    //            `stack` -> ________________________v
+
+    // Enter the target compartment
+    bl         comp_enter
+    // Restore the source DDC and the SP
+    ldp        c1, clr, [sp], #32
+    ldr        x10, [sp], #16
+    msr        ddc, c1
+    mov        sp, x10
+    ret        clr
+
+// Enter the specified compartment
+//
+// Arguments:
+//   C0 - the SP of the compartment
+//   C1 - the PCC of the compartment
+//   C2 - the DDC of the compartment
+//   C3 - the address to jump to within the compartment
+.globl enter_compartment
+.hidden enter_compartment
+enter_compartment:
+    cvtp       clr, lr
+    // Save the old DDC
+    mrs        c9, DDC
+    // Save the old SP
+    mov        x10, sp
+    // Install the new SP
+    mov        sp, x0
+    // Store the old CFP, CLR on the new stack
+    stp        cfp, clr, [sp, #-64]!
+    // Save the old DDC (C9) on the new stack
+    str        c9, [sp, #32]
+    // Save the old SP (X10) on the new stack
+    str        x10, [sp, #48]
+
+    // Stack layout at this point:
+    //
+    //     `stack + size` -> ________________________
+    //            sp + 54 -> [  <alignment pad>  ]   ^
+    //            sp + 48 -> [      old SP       ]   |
+    //            sp + 40 -> [ old DDC (high 64) ]   |
+    //            sp + 32 -> [ old DDC (low 64)  ]   |
+    //            sp + 24 -> [ old CLR (hi64)    ]   |
+    //            sp + 16 -> [ old CLR (lo64)    ]   | DDC bounds
+    //            sp +  8 -> [ old CFP (high 64) ]   |
+    //            sp +  0 -> [ old CFP (low 64)  ]   |
+    //                                 :             :
+    //            `stack` -> ________________________v
+
+    // Install compartment DDC
+    msr        DDC, c2
+    // C3 contains the address to jump to
+    mov        c0, c3
+    // Jump into the compartment.
+    //
+    // NOTE: This instruction jumps to the address specified in the PCC, which
+    // is not necessarily the appropriate place to enter the compartment. For
+    // this reason, the code of every compartment is preceded by a trampoline,
+    // which jumps to the desired entry point (specified in X0).
+    blr        c1
+
+    // Restore CFP, CLR
+    ldp        cfp, clr, [sp]
+    // Restore DDC, stack
+    ldr        c9, [sp, #32]
+    ldr        x10, [sp, #48]
+    msr        DDC, c9
+    mov        sp, x10
+    ret

--- a/test.bats
+++ b/test.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+# Run the specified example.
+#
+# $1 - the name of the example to run
+run_example() (
+    ssh -p "$SSHPORT" "$RUNUSER@$RUNHOST" -t "cd $RUNDIR/cheri-comp && LD_LIBRARY_PATH=./bin/ ./bin/tests/$1"
+)
+
+@test "simple inter-compartment calls succeed" {
+    run run_example simple-comp-switch
+    [ "${status}" -eq 0 ]
+}
+
+@test "nested inter-compartment calls succeed" {
+    run run_example nested-comp-switch
+    [ "${status}" -eq 0 ]
+}
+
+@test "out-of-compartment-bounds calls trigger SIGPROT" {
+    run run_example out-of-bounds-call
+    [ "${status}" -ne 0 ]
+}

--- a/tests/nested-comp-switch/glue.S
+++ b/tests/nested-comp-switch/glue.S
@@ -1,0 +1,41 @@
+#include <asmacros.h>
+
+// TODO make sure the trampolines stay at the *beginning* of each section
+.section .cheri_comp_foo
+
+// void __foo_trampoline(void *__capability target_addr);
+.globl __foo_trampoline
+__foo_trampoline:
+    TRAMPOLINE
+
+.section .cheri_comp_bar
+
+// void __bar_trampoline(void *__capability target_addr);
+.globl __bar_trampoline
+__bar_trampoline:
+    TRAMPOLINE
+
+.section .cheri_comp_baz
+
+// void __baz_trampoline(void *__capability target_addr);
+.globl __baz_trampoline
+__baz_trampoline:
+    TRAMPOLINE
+
+.section .cheri_comp_foo
+
+.globl __foo_switch_glue
+__foo_switch_glue:
+    SWITCH_GLUE
+
+.section .cheri_comp_bar
+
+.globl __bar_switch_glue
+__bar_switch_glue:
+    SWITCH_GLUE
+
+.section .cheri_comp_baz
+
+.globl __baz_switch_glue
+__baz_switch_glue:
+    SWITCH_GLUE

--- a/tests/nested-comp-switch/main.c
+++ b/tests/nested-comp-switch/main.c
@@ -1,0 +1,58 @@
+#include <comp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * Compartment baz
+ */
+__comp("baz") void
+baz(void) {
+    // todo: do something
+}
+
+/*
+ * Compartment bar
+ */
+__comp("bar") void
+bar(void) {
+    comp_call(bar, baz);
+}
+
+__comp("bar") void
+qux(void) {
+    // todo: do something
+}
+
+/*
+ * Compartment foo
+ */
+__comp("foo") void
+foo(void) {
+    // Compartment bar can be entered via any of its functions
+    comp_call(foo, bar);
+    comp_call(foo, qux);
+}
+
+__comp("foo") void
+comp_entry(void) {
+    foo();
+}
+
+int
+main(int argc __attribute__((unused)), char **argv) {
+    if (comp_init(argv[0])) {
+        perror("failed to initialize compartmentalization lib");
+
+        return EXIT_FAILURE;
+    }
+
+    // NOTE: `comp_entry` is not the only entry point of the foo compartment. We
+    // could've just as well entered the compartment through `foo`.
+    if (comp_enter(comp_entry)) {
+        perror("failed to enter compartment");
+
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/tests/out-of-bounds-call/glue.S
+++ b/tests/out-of-bounds-call/glue.S
@@ -1,0 +1,25 @@
+#include <asmacros.h>
+
+// TODO make sure the trampolines stay at the *beginning* of each section
+.section .cheri_comp_foo
+
+// void __foo_trampoline(void *__capability target_addr);
+.globl __foo_trampoline
+__foo_trampoline:
+    TRAMPOLINE
+
+// void __bar_trampoline(void *__capability target_addr);
+.globl __bar_trampoline
+__bar_trampoline:
+    TRAMPOLINE
+.section .cheri_comp_foo
+
+.globl __foo_switch_glue
+__foo_switch_glue:
+    SWITCH_GLUE
+
+.section .cheri_comp_bar
+
+.globl __bar_switch_glue
+__bar_switch_glue:
+    SWITCH_GLUE

--- a/tests/out-of-bounds-call/main.c
+++ b/tests/out-of-bounds-call/main.c
@@ -1,0 +1,38 @@
+#include <comp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__comp("bar") void bar(void);
+
+/*
+ * Compartment foo
+ */
+__comp("foo") void
+foo(void) {
+    bar();
+}
+
+/*
+ * Compartment bar
+ */
+__comp("bar") void
+bar(void) {
+    // Unreachable, because calling bar from foo will trigger a SIGPROT.
+}
+
+int
+main(int argc __attribute__((unused)), char **argv) {
+    if (comp_init(argv[0])) {
+        perror("failed to initialize compartmentalization lib");
+
+        return EXIT_FAILURE;
+    }
+
+    if (comp_enter(foo)) {
+        perror("failed to enter compartment");
+
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/tests/simple-comp-switch/glue.S
+++ b/tests/simple-comp-switch/glue.S
@@ -1,0 +1,28 @@
+#include <asmacros.h>
+
+// TODO make sure the trampolines stay at the *beginning* of each section
+.section .cheri_comp_foo
+
+// void __foo_trampoline(void *__capability target_addr);
+.globl __foo_trampoline
+__foo_trampoline:
+    TRAMPOLINE
+
+.section .cheri_comp_bar
+
+// void __bar_trampoline(void *__capability target_addr);
+.globl __bar_trampoline
+__bar_trampoline:
+    TRAMPOLINE
+
+.section .cheri_comp_foo
+
+.globl __foo_switch_glue
+__foo_switch_glue:
+    SWITCH_GLUE
+
+.section .cheri_comp_bar
+
+.globl __bar_switch_glue
+__bar_switch_glue:
+    SWITCH_GLUE

--- a/tests/simple-comp-switch/main.c
+++ b/tests/simple-comp-switch/main.c
@@ -1,0 +1,37 @@
+#include <comp.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__comp("bar") void bar(void);
+
+/*
+ * Compartment foo
+ */
+__comp("foo") void
+foo(void) {
+    comp_call(foo, bar);
+}
+
+/*
+ * Compartment bar
+ */
+__comp("bar") void
+bar(void) {
+}
+
+int
+main(int argc __attribute__((unused)), char **argv) {
+    if (comp_init(argv[0])) {
+        perror("failed to initialize compartmentalization lib");
+
+        return EXIT_FAILURE;
+    }
+
+    if (comp_enter(foo)) {
+        perror("failed to enter compartment");
+
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This adds a proof-of-concept hybrid compartmentalization library for CheriBSD (for the `morello-hybrid` target).

The aim of the library is to provide tooling for compartmentalizing existing C programs with respect to code and data. It aims to support:
* execution compartmentalization: the PCC of each compartment is restricted according to the bounds established (statically) using the `__comp(COMP_NAME)` macro
* data compartmentalization: compartments have separate and non-overlapping data regions (TODO: this restriction will need to be relaxed to support data sharing between compartments)

The implementation is heavily inspired by [`inter_comp_call` hybrid compartmentalization examples] from the CapableVMs [cheri-examples] repository. It doesn't add anything new other than the use of sections to delineate compartment boundaries (for execution compartmentalization), and support for compartments with multiple entry points.

See `README.md` for more details.

[`inter_comp_call` hybrid compartmentalization examples]: https://github.com/capablevms/cheri-examples/blob/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0/hybrid/compartment_examples/inter_comp_call/malicious_compartments/shared/switch_compartment.S
[cheri-examples]: https://github.com/capablevms/cheri-examples/tree/d6ecb72aaa479f6126a69b9e70de1ec2fc49cdc0